### PR TITLE
feature(PLAT-1827): add loader bar for 3 seconds after load webview

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 ext {
-    urlMaven = System.getProperty("urlMaven", "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
+    urlMaven = System.getProperty("urlMaven", "https://s01.oss.sonatype.org/content/repositories/snapshots/") // "https://s01.oss.sonatype.org/content/repositories/snapshots/"
     usernameMaven = System.getProperty("usernameMaven", "developersdeuna")
     passwordMaven = System.getProperty("passwordMaven", "J>y@RT]3>[v2%jM")
 }
@@ -44,7 +44,7 @@ publishing {
         maven(MavenPublication) {
             groupId 'com.deuna.maven'
             artifactId 'deunasdk'
-            version '1.0.5'
+            version '1.0.6-SNAPSHOT'
             artifact("$buildDir/outputs/aar/deuna-sdk-android-release.aar")
             pom {
                 name = 'Android SDK DEUNA'

--- a/src/main/java/com/deuna/maven/checkout/DeunaActivity.kt
+++ b/src/main/java/com/deuna/maven/checkout/DeunaActivity.kt
@@ -22,6 +22,10 @@ import com.deuna.maven.R
 import com.deuna.maven.checkout.domain.DeUnaBridge
 import com.deuna.maven.checkout.domain.DeunaErrorMessage
 import com.deuna.maven.client.sendOrder
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
@@ -33,6 +37,9 @@ import java.net.URL
 class DeunaActivity : AppCompatActivity() {
 
     lateinit var instance: DeunaActivity
+
+    private val scope = CoroutineScope(Dispatchers.Main)
+
 
     companion object {
         const val ORDER_TOKEN = "order_token"
@@ -60,12 +67,20 @@ class DeunaActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_deuna)
         instance = this
-        getOrderApi(
-            intent.getStringExtra(BASE_URL)!!,
-            intent.getStringExtra(ORDER_TOKEN)!!,
-            intent.getStringExtra(API_KEY)!!,
-            intent.getStringArrayListExtra(CLOSE_ON_EVENTS)
-        )
+        setProgressBarVisibilityBar(true)
+
+
+        scope.launch {
+            delay(3000L)
+            getOrderApi(
+                intent.getStringExtra(BASE_URL)!!,
+                intent.getStringExtra(ORDER_TOKEN)!!,
+                intent.getStringExtra(API_KEY)!!,
+                intent.getStringArrayListExtra(CLOSE_ON_EVENTS)
+            )
+            setProgressBarVisibilityBar(false)
+        }
+
         registerReceiver(closeAllReceiver, IntentFilter("com.deuna.maven.CLOSE_CHECKOUT"))
     }
 

--- a/src/main/java/com/deuna/maven/element/DeunaElementActivity.kt
+++ b/src/main/java/com/deuna/maven/element/DeunaElementActivity.kt
@@ -22,8 +22,14 @@ import com.deuna.maven.R
 import com.deuna.maven.checkout.DeunaActivity
 import com.deuna.maven.element.domain.DeUnaElementBridge
 import com.deuna.maven.element.domain.ElementCallbacks
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 class DeunaElementActivity : AppCompatActivity() {
+
+    private val scope = CoroutineScope(Dispatchers.Main)
 
     companion object {
         const val EXTRA_URL = "extra_url"
@@ -54,12 +60,26 @@ class DeunaElementActivity : AppCompatActivity() {
         setContentView(R.layout.activity_deuna_element)
         val url = intent.getStringExtra(EXTRA_URL)
         val webView: WebView = findViewById(R.id.deuna_webview_element)
-        setupWebView(webView,  intent.getStringArrayListExtra(DeunaActivity.CLOSE_ON_EVENTS))
-        if (url != null) {
-            webView.visibility = View.VISIBLE
-            loadUrlWithNetworkCheck(webView, this, url)
-            registerReceiver(closeAllReceiver, IntentFilter("com.deuna.maven.CLOSE_ELEMENTS"))
+
+        setProgressBarVisibilityBar(true)
+
+        scope.launch {
+            delay(3000L)
+            setupWebView(webView,  intent.getStringArrayListExtra(DeunaActivity.CLOSE_ON_EVENTS))
+            if (url != null) {
+                webView.visibility = View.VISIBLE
+                setProgressBarVisibilityBar(false)
+                loadUrlWithNetworkCheck(webView, this@DeunaElementActivity, url)
+                registerReceiver(closeAllReceiver, IntentFilter("com.deuna.maven.CLOSE_ELEMENTS"))
+            }
         }
+
+
+    }
+
+    fun setProgressBarVisibilityBar(visible: Boolean) {
+        val progressBar: ProgressBar = findViewById(R.id.progress_circular_element)
+        progressBar.visibility = if (visible) View.VISIBLE else View.GONE
     }
 
     /**


### PR DESCRIPTION
ISSUE: https://deuna.atlassian.net/browse/PLAT-1827

Objetivo:

Mitigar la pantalla de carga entre la app integradora y nuestro SDK

Observaciones:

Si bien no se logra replicar el escenario reportado, se espera que con el loader de la sensación de que está cargando y luego en Checkout o Vault se pueda implementar algún Skeleton

Evidencia:


https://github.com/DUNA-E-Commmerce/deuna-sdk-android/assets/13279526/a9a16375-7278-480d-bffd-b00737316dc4

