### PR TITLE
chore(2.0.1): Fixed bad elements URL on production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [2.0.1]
+- Fixed bad elements URL on production.
+
 ## [2.0.0]
 
 ### Changed

--- a/examples/basic-integration-jetpack-compose/app/src/main/java/com/deuna/compose_demo/MainActivity.kt
+++ b/examples/basic-integration-jetpack-compose/app/src/main/java/com/deuna/compose_demo/MainActivity.kt
@@ -28,8 +28,8 @@ class MainActivity() : ComponentActivity() {
               // Initialize the view model with DeunaSDK configuration for sandbox environment
               homeViewModel = HomeViewModel(
                 deunaSDK = DeunaSDK(
-                  environment = Environment.STAGING,
-                  publicApiKey = "77c319962031a1762d98b5a5dff8916c0070a71b747a4104fc88e3f1269653ccfc2b49a6f224af3aa7c0677b8d9210099480d48b7f3461a95efb39117c00"
+                  environment = Environment.SANDBOX,
+                  publicApiKey = "YOUR_PUBLIC_API_KEY"
                 ),
               )
             )

--- a/src/main/java/com/deuna/maven/shared/Environment.kt
+++ b/src/main/java/com/deuna/maven/shared/Environment.kt
@@ -10,7 +10,7 @@ enum class Environment(
     ),
     PRODUCTION(
         "https://api.deuna.io",
-        "https://elements.deuna.io"
+        "https://elements.deuna.com"
     ),
     STAGING(
         "https://api.stg.deuna.io",


### PR DESCRIPTION
Changed `https://elements.deuna.io` to `https://elements.deuna.com`