### PR TITLE
feat(ENTP1-13493): Agregar nuevos campos en initElements - Android

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ afterEvaluate {
                 from components.release
                 groupId 'com.github.deuna-developers'
                 artifactId 'deunasdk'
-                version '2.8.12'
+                version '2.8.13'
             }
         }
     }

--- a/examples/basic-integration-jetpack-compose/app/build.gradle
+++ b/examples/basic-integration-jetpack-compose/app/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     implementation("com.squareup.retrofit2:converter-gson:2.9.0")
 
     // DEUNA SDK
-    implementation 'com.github.deuna-developers:deuna-sdk-android:2.8.12'
+    implementation 'com.github.deuna-developers:deuna-sdk-android:2.8.13'
 
 
     // Material Design 3

--- a/examples/basic-integration-jetpack-compose/app/src/main/java/com/deuna/compose_demo/view_models/home/initElementsVault.kt
+++ b/examples/basic-integration-jetpack-compose/app/src/main/java/com/deuna/compose_demo/view_models/home/initElementsVault.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.Log
 import androidx.lifecycle.viewModelScope
 import com.deuna.compose_demo.screens.ElementsResult
+import com.deuna.maven.ElementsWidgetExperience
 import com.deuna.maven.initElements
 import com.deuna.maven.shared.ElementsCallbacks
 import com.deuna.maven.shared.Json
@@ -20,7 +21,8 @@ fun HomeViewModel.saveCard(
     context: Context,
     completion: (ElementsResult) -> Unit,
 ) {
-    deunaSDK.initElements(context = context,
+    deunaSDK.initElements(
+        context = context,
         userToken = userTokenValue,
         userInfo = if (userTokenValue == null) UserInfo(
             firstName = "Darwin", lastName = "Morocho", email = "dmorocho@deuna.com"
@@ -53,7 +55,13 @@ fun HomeViewModel.saveCard(
             onEventDispatch = { event, data ->
                 Log.d(DEBUG_TAG, "onEventDispatch ${event.name}: $data")
             }
-        })
+        },
+        widgetExperience = ElementsWidgetExperience(
+            userExperience = ElementsWidgetExperience.UserExperience(
+                showSavedCardFlow = false, defaultCardFlow = false
+            )
+        ),
+    )
 }
 
 

--- a/examples/basic-integration/app/build.gradle.kts
+++ b/examples/basic-integration/app/build.gradle.kts
@@ -50,7 +50,7 @@ dependencies {
             strictly("2.8.9")
         }
     }
-    implementation("com.github.deuna-developers:deuna-sdk-android:2.8.12")
+    implementation("com.github.deuna-developers:deuna-sdk-android:2.8.13")
 
     annotationProcessor("com.github.bumptech.glide:compiler:4.12.0")
     testImplementation("junit:junit:4.13.2")

--- a/src/main/java/com/deuna/maven/InitElements.kt
+++ b/src/main/java/com/deuna/maven/InitElements.kt
@@ -25,6 +25,20 @@ import java.lang.IllegalStateException
  *    mapOf( "name" to ElementsWidget.VAULT)
  * )
  * ```
+ * @param orderToken (Optional) The orderToken is a unique token generated for the payment order. This token is generated through the DEUNA API and you must implement the corresponding endpoint in your backend to obtain this information.
+ * @param widgetExperience (Optional)  A dictionary containing custom configurations for the widget.
+ *  The currently supported configurations are:
+ *   - `userExperience.showSavedCardFlow`: (Bool) Shows the saved cards toggle.
+ *   - `userExperience.defaultCardFlow`: (Bool) Shows the toggle to save the card as default.
+ * Example:
+ * ```
+ * widgetExperience = mapOf(
+ *      "userExperience" to mapOf(
+ *         "showSavedCardFlow" to true,
+ *         "defaultCardFlow" to true,
+ *      )
+ * )
+ * ```
  * @throws IllegalStateException if the passed userToken is not valid
  */
 fun DeunaSDK.initElements(
@@ -35,7 +49,9 @@ fun DeunaSDK.initElements(
     userInfo: UserInfo? = null,
     styleFile: String? = null,
     types: List<Json> = emptyList(),
-    language: String? = null
+    language: String? = null,
+    orderToken: String? = null,
+    widgetExperience: Json = emptyMap()
 ) {
     val baseUrl = this.environment.elementsBaseUrl
 
@@ -65,6 +81,14 @@ fun DeunaSDK.initElements(
 
     if (!language.isNullOrEmpty()) {
         queryParameters[QueryParameters.LANGUAGE] = language
+    }
+
+    if (!orderToken.isNullOrEmpty()) {
+        queryParameters[QueryParameters.ORDER_TOKEN] = orderToken
+    }
+
+    if (widgetExperience.isNotEmpty()) {
+        queryParameters[QueryParameters.WIDGET_EXPERIENCE] = widgetExperience.toBase64()
     }
 
     styleFile?.let {

--- a/src/main/java/com/deuna/maven/InitElements.kt
+++ b/src/main/java/com/deuna/maven/InitElements.kt
@@ -11,7 +11,7 @@ import java.lang.IllegalStateException
 
 
 class ElementsWidgetExperience(val userExperience: UserExperience) {
-    inner class UserExperience(
+    class UserExperience(
         val showSavedCardFlow: Boolean? = null,
         val defaultCardFlow: Boolean? = null,
     )

--- a/src/main/java/com/deuna/maven/shared/Constants.kt
+++ b/src/main/java/com/deuna/maven/shared/Constants.kt
@@ -39,7 +39,8 @@ object QueryParameters {
     const val LAST_NAME = "lastName"
     const val EMAIL = "email"
     const val LANGUAGE = "language"
-    const val WIDGET_EXPERIENCE = "widgetExperience"
+    const val SHOW_SAVED_CARD_FLOW = "showSavedCardFlow"
+    const val DEFAULT_CARD_FLOW = "defaultCardFlow"
 }
 
 object PaymentsErrorMessages {

--- a/src/main/java/com/deuna/maven/shared/Constants.kt
+++ b/src/main/java/com/deuna/maven/shared/Constants.kt
@@ -30,6 +30,7 @@ object QueryParameters {
     const val XPROPS_B64 = "xpropsB64"
     const val PUBLIC_API_KEY = "publicApiKey"
     const val USER_TOKEN = "userToken"
+    const val ORDER_TOKEN = "orderToken"
     const val CSS_FILE = "cssFile"
     const val STYLE_FILE = "styleFile"
     const val PAYMENT_METHODS = "paymentMethods"
@@ -38,6 +39,7 @@ object QueryParameters {
     const val LAST_NAME = "lastName"
     const val EMAIL = "email"
     const val LANGUAGE = "language"
+    const val WIDGET_EXPERIENCE = "widgetExperience"
 }
 
 object PaymentsErrorMessages {


### PR DESCRIPTION
Adaptar la función initElements en los sdks mobiles para que soporten los campos de orderToken y widgetExperience segun se muestra en la documentación del web SDK

[TICKET](https://deuna.atlassian.net/browse/ENTP1-13493)

Evidencia

https://github.com/user-attachments/assets/3bd9f9d2-bc82-4d5a-a438-8214c575c303

